### PR TITLE
ci(api): add mockable API integration tests on GitHub Actions

### DIFF
--- a/docs/QA_PLAN.md
+++ b/docs/QA_PLAN.md
@@ -1,0 +1,13 @@
+# QA Plan: API Integration (Mock Mode)
+
+Scope:
+- Add USE_MOCK_API gate in endpoints for CI.
+- Add GitHub Actions workflow to run black-box API tests without real DB.
+
+Verification Steps:
+1) CI triggers on PR; workflow api-integration runs.
+2) API starts with USE_MOCK_API=true; health endpoint 200.
+3) Tests in tests/integration/test_dashboard_anomalies_int.py pass.
+
+Risks/Notes:
+- Mock only in CI via env; no production impact.


### PR DESCRIPTION
This PR adds:\n- USE_MOCK_API gate in dashboard/anomalies endpoints (CI-only)\n- API integration workflow running black-box tests without a real DB\n- QA plan in docs/QA_PLAN.md\n\nQA Steps:\n1) CI should run api-integration workflow on this PR\n2) API starts with USE_MOCK_API=true and health returns 200\n3) Tests pass: tests/integration/test_dashboard_anomalies_int.py\n\nRisk: mock path is guarded by env; no prod impact.