### PR TITLE
fix(weather): resolve weather page broken endpoints

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -4,12 +4,7 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   async rewrites() {
-    return [
-      {
-        source: '/api/weather/:path*',
-        destination: 'http://localhost:8000/weather/:path*',
-      },
-    ];
+    return [];
   },
   async headers() {
     return [

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -7,25 +7,7 @@ const nextConfig = {
     return [];
   },
   async headers() {
-    return [
-      {
-        source: '/api/weather/:path*',
-        headers: [
-          {
-            key: 'Access-Control-Allow-Origin',
-            value: '*',
-          },
-          {
-            key: 'Access-Control-Allow-Methods',
-            value: 'GET, POST, PUT, DELETE, OPTIONS',
-          },
-          {
-            key: 'Access-Control-Allow-Headers',
-            value: 'Content-Type, Authorization',
-          },
-        ],
-      },
-    ];
+    return [];
   },
 };
 

--- a/frontend/src/app/weather/page.tsx
+++ b/frontend/src/app/weather/page.tsx
@@ -105,7 +105,7 @@ const WeatherAnalyticsPage = () => {
         setError(null);
         
         // Fetch locations
-        const locationsRes = await fetch('/api/weather/locations');
+        const locationsRes = await fetch('/api/proxy/v1/weather/locations');
         if (!locationsRes.ok) {
           throw new Error(`Failed to fetch locations: ${locationsRes.status}`);
         }
@@ -114,8 +114,8 @@ const WeatherAnalyticsPage = () => {
 
         // Fetch current weather
         const currentUrl = selectedLocation === 'all' 
-          ? '/api/weather/current'
-          : `/api/weather/current?location=${selectedLocation}`;
+          ? '/api/proxy/v1/weather/current'
+          : `/api/proxy/v1/weather/current?location=${selectedLocation}`;
         const currentRes = await fetch(currentUrl);
         if (!currentRes.ok) {
           throw new Error(`Failed to fetch current weather: ${currentRes.status}`);
@@ -136,7 +136,7 @@ const WeatherAnalyticsPage = () => {
         }
         
         // Build the URL with optional location parameter
-        let historicalUrl = `/api/weather/historical?start_date=${startDate.toISOString().split('T')[0]}&end_date=${endDate.toISOString().split('T')[0]}&interval=${interval}`;
+        let historicalUrl = `/api/proxy/v1/weather/historical?start_date=${startDate.toISOString().split('T')[0]}&end_date=${endDate.toISOString().split('T')[0]}&interval=${interval}`;
         if (selectedLocation !== 'all') {
           historicalUrl += `&location=${selectedLocation}`;
         }
@@ -163,8 +163,8 @@ const WeatherAnalyticsPage = () => {
 
         // Fetch statistics
         const statsUrl = selectedLocation === 'all'
-          ? '/api/weather/statistics'
-          : `/api/weather/statistics?location=${selectedLocation}`;
+          ? '/api/proxy/v1/weather/statistics'
+          : `/api/proxy/v1/weather/statistics?location=${selectedLocation}`;
         const statsRes = await fetch(statsUrl);
         if (!statsRes.ok) {
           throw new Error(`Failed to fetch statistics: ${statsRes.status}`);
@@ -173,7 +173,7 @@ const WeatherAnalyticsPage = () => {
         setStatistics(statsData);
 
         // Fetch impact analysis
-        const impactRes = await fetch('/api/weather/impact-analysis');
+        const impactRes = await fetch('/api/proxy/v1/weather/impact-analysis');
         if (!impactRes.ok) {
           throw new Error(`Failed to fetch impact analysis: ${impactRes.status}`);
         }

--- a/src/presentation/api/endpoints/weather_router.py
+++ b/src/presentation/api/endpoints/weather_router.py
@@ -5,7 +5,7 @@ import random
 import json
 from pydantic import BaseModel
 
-router = APIRouter(prefix="/weather", tags=["weather"])
+router = APIRouter(prefix="/api/v1/weather", tags=["weather"])
 
 # Weather data models
 class WeatherLocation(BaseModel):

--- a/tests/integration/test_weather_endpoints.int.py
+++ b/tests/integration/test_weather_endpoints.int.py
@@ -1,0 +1,57 @@
+"""Integration tests for weather endpoints following DEV-PROTO.yaml TDD."""
+
+import pytest
+import httpx
+
+API_BASE = "http://localhost:8000/api/v1"
+
+
+def test_weather_current_endpoint_returns_valid_response():
+    """Should return current weather data with correct API prefix."""
+    url = f"{API_BASE}/weather/current"
+    response = httpx.get(url, timeout=10)
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) > 0
+    
+    # Check first weather entry structure
+    weather_entry = data[0]
+    required_fields = ['location', 'date', 'temperature', 'humidity', 'rainfall', 'windSpeed', 'conditions']
+    for field in required_fields:
+        assert field in weather_entry
+
+
+def test_weather_locations_endpoint_returns_valid_response():
+    """Should return weather locations with correct API prefix."""
+    url = f"{API_BASE}/weather/locations"
+    response = httpx.get(url, timeout=10)
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) > 0
+
+
+def test_weather_statistics_endpoint_returns_valid_response():
+    """Should return weather statistics with correct API prefix."""
+    url = f"{API_BASE}/weather/statistics"
+    response = httpx.get(url, timeout=10)
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert 'overview' in data
+    assert 'seasonalPatterns' in data
+
+
+def test_weather_impact_analysis_endpoint_returns_valid_response():
+    """Should return weather impact analysis with correct API prefix."""
+    url = f"{API_BASE}/weather/impact-analysis"
+    response = httpx.get(url, timeout=10)
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert 'temperatureImpact' in data
+    assert 'rainfallImpact' in data
+    assert 'recommendations' in data


### PR DESCRIPTION
## Summary
- Fixed weather page completely broken issue where no data was loading
- Updated weather router prefix from `/weather` to `/api/v1/weather` for consistency with other API endpoints
- Updated frontend weather page to use correct proxy paths (`/api/proxy/v1/weather/*`)
- Removed conflicting Next.js rewrite rules for weather endpoints
- Added comprehensive integration tests following TDD methodology

## Root Cause
The weather router used `/weather` prefix while all other APIs used `/api/v1/` pattern, causing 404 errors when the frontend tried to access weather data through the standard proxy pattern.

## Changes
- **Backend**: Updated weather router prefix in `src/presentation/api/endpoints/weather_router.py`
- **Frontend**: Updated all weather API calls in `frontend/src/app/weather/page.tsx`
- **Configuration**: Cleaned up `frontend/next.config.js` by removing special weather rewrites
- **Tests**: Added integration tests in `tests/integration/test_weather_endpoints.int.py`

## Test Plan
- [x] Weather endpoints respond correctly at `/api/v1/weather/*`
- [x] Integration tests pass for all weather endpoints
- [x] Frontend weather page loads data successfully
- [x] API routing consistency maintained across all endpoints

🤖 Generated with [Claude Code](https://claude.ai/code)