### PR TITLE
fix(weather): resolve weather page infrastructure and API routing issues

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -2,8 +2,8 @@ module.exports = {
   apps: [
     {
       name: 'abbanoa-backend',
-      script: '/bin/bash',
-      args: '-lc "export PATH=\\"$HOME/.local/bin:$PATH\\"; cd src && poetry run uvicorn presentation.api.app_postgres:app --reload --host 0.0.0.0 --port 8000"',
+      script: 'python3',
+      args: '-m uvicorn src.presentation.api.app_postgres:app --reload --host 0.0.0.0 --port 8000',
       cwd: '/root/abbanoa-water-analysis',
       env: {
         USE_MOCK_API: 'true',
@@ -11,7 +11,8 @@ module.exports = {
         POSTGRES_PORT: '5432',
         POSTGRES_DB: 'abbanoa_processing',
         POSTGRES_USER: 'abbanoa_user',
-        POSTGRES_PASSWORD: 'abbanoa_dev_pass'
+        POSTGRES_PASSWORD: 'abbanoa_dev_pass',
+        PYTHONPATH: '/root/abbanoa-water-analysis'
       },
       error_file: 'logs/pm2-backend-error.log',
       out_file: 'logs/pm2-backend-out.log',
@@ -24,7 +25,7 @@ module.exports = {
       args: 'run dev',
       cwd: '/root/abbanoa-water-analysis/frontend',
       env: {
-        PORT: '3000'
+        PORT: '3001'
       }
     }
   ]

--- a/frontend/src/app/api/proxy/[...path]/route.ts
+++ b/frontend/src/app/api/proxy/[...path]/route.ts
@@ -42,7 +42,10 @@ async function proxyRequest(
   try {
     // Reconstruct the path
     const path = pathSegments.join('/');
-    const url = `${BACKEND_URL}/api/${path}`;
+    // Get query parameters from the original request
+    const searchParams = request.nextUrl.searchParams.toString();
+    const queryString = searchParams ? `?${searchParams}` : '';
+    const url = `${BACKEND_URL}/api/${path}${queryString}`;
     
 
     

--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -35,11 +35,11 @@ http {
 
     # Upstream definitions - pointing to host machine
     upstream frontend {
-        server host.docker.internal:3001;
+        server 172.17.0.1:3001;
     }
     
     upstream api {
-        server host.docker.internal:8000;
+        server 172.17.0.1:8000;
     }
 
     # HTTP server - redirect to HTTPS
@@ -87,25 +87,37 @@ http {
             proxy_read_timeout 86400;
         }
 
-        # Weather page - direct access to current weather
+        # Weather page - proxy to frontend (Next.js handles routing)
         location /weather {
-            proxy_pass http://api/weather/current;
+            proxy_pass http://frontend;
             proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            
-            # CORS headers
-            add_header 'Access-Control-Allow-Origin' 'https://curator.abbanoa.aigensolutions.it' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
-            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+            proxy_cache_bypass $http_upgrade;
+            proxy_read_timeout 86400;
         }
 
-        # API endpoints - proxy to weather API
-        location /api/weather/ {
-            proxy_pass http://api/weather/;
+        # Frontend API proxy routes (more specific, handled first)
+        location /api/proxy/ {
+            proxy_pass http://frontend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_cache_bypass $http_upgrade;
+            proxy_read_timeout 86400;
+        }
+        
+        # Backend API endpoints - direct to backend
+        location /api/ {
+            proxy_pass http://api/;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- Fixed weather page completely broken state with all data now loading correctly
- Resolved nginx upstream routing from non-working `host.docker.internal` to proper `172.17.0.1`
- Added `/api/proxy/` routing to handle Next.js API proxy requests properly
- Fixed Next.js proxy route to forward query parameters to backend API (resolves 422 errors)

## Infrastructure Changes
- **nginx/nginx-ssl.conf**: Updated upstream servers and added API proxy routing
- **ecosystem.config.js**: Simplified PM2 configuration for more reliable process management
- **frontend/src/app/api/proxy/[...path]/route.ts**: Added query parameter forwarding

## Test Results
All weather API endpoints now return HTTP 200:
- ✅ `/api/proxy/v1/weather/locations`
- ✅ `/api/proxy/v1/weather/current`
- ✅ `/api/proxy/v1/weather/statistics`
- ✅ `/api/proxy/v1/weather/impact-analysis`
- ✅ `/api/proxy/v1/weather/historical` (with proper date parameters)

## Test plan
- [x] Weather page loads without errors at https://curator.abbanoa.aigensolutions.it/weather
- [x] All weather data sections display correctly
- [x] Historical data loads with proper date filtering
- [x] No "Failed to fetch" errors in browser console
- [x] All API endpoints return valid JSON data

🤖 Generated with [Claude Code](https://claude.ai/code)