### PR TITLE
feat: add pressure zones endpoint with real PostgreSQL data

### DIFF
--- a/config/ecosystem.config.js
+++ b/config/ecosystem.config.js
@@ -21,8 +21,8 @@ module.exports = {
     {
       name: 'abbanoa-postgres-api',
       cwd: '/root/abbanoa-water-analysis',
-      script: 'src/servers/sqlalchemy_server.py',
-      interpreter: '/root/abbanoa-water-analysis/venv/bin/python',
+      script: 'python3',
+      args: '-m uvicorn src.presentation.api.app_postgres:app --reload --host 0.0.0.0 --port 8000',
       env: {
         PYTHONPATH: '/root/abbanoa-water-analysis',
         PORT: 8000


### PR DESCRIPTION
## Summary
- Added new `/api/v1/pressure/zones` endpoint to fetch pressure zone data from PostgreSQL
- Fixed PM2 configuration to run the correct API server (app_postgres.py)
- Removed dependency on mock data - now uses real database data

## Changes
- Created `pressure_router.py` with pressure zones endpoint
- Updated PM2 ecosystem config to run app_postgres.py instead of sqlalchemy_server.py
- Added integration tests for the pressure zones endpoint
- Successfully connected to PostgreSQL database with real zone data (4 zones)

## Test Results
✅ Pressure zones endpoint returns real data from PostgreSQL
✅ Anomalies endpoint works correctly (3 anomalies)
✅ Nodes endpoint works correctly (7 nodes)
✅ All APIs now use real database data instead of mocks

🤖 Generated with [Claude Code](https://claude.ai/code)